### PR TITLE
chore: bump gateway-api to 1.32.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>1.4</gravitee-bom.version>
         <gravitee-common.version>1.23.1</gravitee-common.version>
-        <gravitee-gateway-api.version>1.31.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.32.3</gravitee-gateway-api.version>
         <gravitee-node-api.version>1.18.3</gravitee-node-api.version>
     </properties>
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7930

**Description**

Bump version of gateway-api to take benefits from fixes on headers (see issue)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.2-issues-7930-fix-es-headers-reporting-3-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-api/1.1.2-issues-7930-fix-es-headers-reporting-3-SNAPSHOT/gravitee-connector-api-1.1.2-issues-7930-fix-es-headers-reporting-3-SNAPSHOT.zip)
  <!-- Version placeholder end -->
